### PR TITLE
fix(render-blueprint): bad filter path

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,16 +1,12 @@
 {
   "recommendations": [
-    // ai
-    "GitHub.copilot",
-
-    // Linting / Formatting
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
+    "GitHub.copilot",
 
-    // PR management / Reviewing
     "github.vscode-pull-request-github",
-
-    // Debugging
-    "ms-vscode.vscode-js-profile-flame"
+    "ms-vscode.vscode-js-profile-flame",
+    "github.vscode-github-actions",
+    "github.github-vscode-theme"
   ]
 }

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
       paths:
         - apps/doc-site/**
       ignoredPaths:
-        - apps/doc-site/**/*.test.[js|ts|jsx|tsx]
+        - apps/doc-site/**/*.test.*
     headers:
       - path: /*
         name: X-Frame-Options


### PR DESCRIPTION
tried to create a blueprint on render.com but got this buildpath issue:

```
services[0].buildFilter.ignoredPaths[0]
apps/doc-site/**/*.test.[js|ts|jsx|tsx] must match re "^[A-za-z0-9-_./\^*? ]+$"
```